### PR TITLE
Added US version of NE-NAS-PD01 PIR motion sensor

### DIFF
--- a/app.json
+++ b/app.json
@@ -1336,7 +1336,8 @@
         "productTypeId": 3,
         "productId": [
           4233,
-          4227
+          4227,
+          4240
         ],
         "learnmode": {
           "instruction": {

--- a/drivers/NE-NAS-PD01Z.EU/driver.compose.json
+++ b/drivers/NE-NAS-PD01Z.EU/driver.compose.json
@@ -7,7 +7,7 @@
     "zwave": {
         "manufacturerId": 305,
         "productTypeId": 3,
-        "productId": [4233, 4227],
+        "productId": [4233, 4227, 4240],
         "learnmode": {
             "instruction": {
                 "en": "Press include/network button three times within 1.5 seconds.",


### PR DESCRIPTION
I have an US version of the PIR sensor, that had a different productID, but everything else is same. After adding the productID I am able to to run it fine. 